### PR TITLE
fix(autocopmplete): regex metacharacter escape

### DIFF
--- a/src/material-examples/autocomplete-overview/autocomplete-overview-example.ts
+++ b/src/material-examples/autocomplete-overview/autocomplete-overview-example.ts
@@ -72,9 +72,16 @@ export class AutocompleteOverviewExample {
         .map(name => this.filterStates(name));
   }
 
+  escapeSpecChars(val: string) {
+    return val ? val.replace(/[\-\[\]\/\{\}\(\)\*\+\?\.\\\^\$\|]/g, "\\$&")
+               : val;
+  }
+
   filterStates(val: string) {
-    return val ? this.states.filter(s => new RegExp(`^${val}`, 'gi').test(s))
+    let escVal: string = this.escapeSpecChars(val);
+    return val ? this.states.filter(s => new RegExp(`^${escVal}`, 'gi').test(s))
                : this.states;
   }
 
 }
+


### PR DESCRIPTION
autocomplete material example fails if regex metacharacter ie. "*" is provided. Fixed by adding escapeSpecChars function